### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -171,7 +171,7 @@ pub fn poll<const N: usize>(
                         .map(|pos| pos.load(Ordering::SeqCst))
                         .collect();
                     format!(
-                        "{{ [{}] [{}] {:.?} }}",
+                        "{{ [{}] [{}] {:?} }}",
                         recent_execution_times.join(", "),
                         average_execution_times.join(", "),
                         execution_positions
@@ -277,7 +277,7 @@ pub fn poll<const N: usize>(
                     .map(|pos| pos.load(Ordering::SeqCst))
                     .collect();
                 format!(
-                    "{{ [{}] [{}] {:.?} }}",
+                    "{{ [{}] [{}] {:?} }}",
                     recent_execution_times.join(", "),
                     average_execution_times.join(", "),
                     execution_positions


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.